### PR TITLE
set content_type only if available

### DIFF
--- a/lib/rack/streaming_proxy/proxy_request.rb
+++ b/lib/rack/streaming_proxy/proxy_request.rb
@@ -15,7 +15,7 @@ class Rack::StreamingProxy
       if proxy_request.request_body_permitted? and request.body
         proxy_request.body_stream = request.body
         proxy_request.content_length = request.content_length
-        proxy_request.content_type = request.content_type
+        proxy_request.content_type = request.content_type if request.content_type
       end
 
       %w(Accept Accept-Encoding Accept-Charset


### PR DESCRIPTION
calling Net::HTTPHeader#content_type=(nil) raises an exception
